### PR TITLE
Added Separate Mouse Click Listener

### DIFF
--- a/Viewer/src/self/lesfoster/cylindrical_alignment/viewer/java_fx/CylinderContainer.java
+++ b/Viewer/src/self/lesfoster/cylindrical_alignment/viewer/java_fx/CylinderContainer.java
@@ -83,6 +83,7 @@ import self.lesfoster.cylindrical_alignment.viewer.java_fx.gui_model.MouseLocati
 import self.lesfoster.framework.integration.SelectionModel;
 import static self.lesfoster.cylindrical_alignment.viewer.appearance_source.AppearanceSource.OPACITY;
 import self.lesfoster.cylindrical_alignment.viewer.java_fx.events.GlyphSelector;
+import self.lesfoster.cylindrical_alignment.viewer.java_fx.events.MouseClickedHandler;
 import self.lesfoster.framework.integration.SelectedObjectWrapper;
 import self.lesfoster.framework.integration.SelectionModelListener;
 
@@ -1394,9 +1395,10 @@ public class CylinderContainer extends JFXPanel
 	// JavaFX 3D Graphics tutorial. 
 	//
 	private void handleMouse(Scene scene) {
+		scene.setOnMouseClicked(new MouseClickedHandler(subEntitySelector));
 		scene.setOnMousePressed(new MousePressedHandler(mouseLocationModel));
 		this.mouseDraggedHandler = new MouseDraggedHandler(mouseLocationModel, cameraModel, idToShape, subEntitySelector);
-		scene.setOnMouseDragged(mouseDraggedHandler);
+		scene.setOnMouseDragged(mouseDraggedHandler);		
 	}
 
 	private void handleKeyboard(Scene scene) {

--- a/Viewer/src/self/lesfoster/cylindrical_alignment/viewer/java_fx/events/MouseClickedHandler.java
+++ b/Viewer/src/self/lesfoster/cylindrical_alignment/viewer/java_fx/events/MouseClickedHandler.java
@@ -1,0 +1,56 @@
+/*
+ CDDL HEADER START
+
+ The contents of this file are subject to the terms of the
+ Common Development and Distribution License (the "License").
+ You may not use this file except in compliance with the License.
+
+ You can obtain a copy of the license at
+   https://opensource.org/licenses/CDDL-1.0.
+ See the License for the specific language governing permissions
+ and limitations under the License.
+
+ When distributing Covered Code, include this CDDL HEADER in each
+ file and include the License file at
+    https://opensource.org/licenses/CDDL-1.0.
+ If applicable, add the following below this CDDL HEADER, with the
+ fields enclosed by brackets "[]" replaced with your own identifying
+ information: Portions Copyright [yyyy] [name of copyright owner]
+
+ CDDL HEADER END
+*/
+
+
+package self.lesfoster.cylindrical_alignment.viewer.java_fx.events;
+
+import javafx.event.EventHandler;
+import javafx.scene.Node;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.input.PickResult;
+import javafx.scene.shape.Shape3D;
+
+/**
+ * Handle mouse click by selecting picked node.
+ * @author Leslie L Foster
+ */
+public class MouseClickedHandler implements EventHandler<MouseEvent> {
+	private final GlyphSelector shapeSelector;
+			
+	public MouseClickedHandler(GlyphSelector glyphSelector) {
+		this.shapeSelector = glyphSelector;
+	}
+	
+	@Override
+	public void handle(MouseEvent me) {			
+		// Select the shape visually.
+		PickResult pr = me.getPickResult();
+		if (pr != null) {
+			Node node = pr.getIntersectedNode();
+			if (node != null && node instanceof Shape3D) {
+				shapeSelector.select(node);
+			}
+		}
+
+	}
+	
+}

--- a/Viewer/src/self/lesfoster/cylindrical_alignment/viewer/java_fx/events/MouseDraggedHandler.java
+++ b/Viewer/src/self/lesfoster/cylindrical_alignment/viewer/java_fx/events/MouseDraggedHandler.java
@@ -89,14 +89,6 @@ public class MouseDraggedHandler implements EventHandler<MouseEvent> {
 			cameraModel.getCameraXform2().t.setY(cameraModel.getCameraXform2().t.getY() + mouseLocationModel.getMouseDeltaY() * modifierFactor * modifier * 0.3);  // -
 		}
 
-		// Select the shape visually.
-		PickResult pr = me.getPickResult();
-		if (pr != null) {
-			Node node = pr.getIntersectedNode();
-			if (node != null && node instanceof Shape3D) {
-				shapeSelector.select(node);
-			}
-		}
 	}
 	
 	public double getModifierFactor() {


### PR DESCRIPTION
Prior to now, the Mouse Drag Listener has been used both for clicking and dragging, meaning that you have to drag in order to click.  Further, any drag caused a select to take place -- also unintended.  Adding this listener and removing that functionality from the drag makes the UI interactions much cleaner.